### PR TITLE
updates to fix easynews

### DIFF
--- a/plugin.video.gaia/resources/lib/debrid/easynews/core.py
+++ b/plugin.video.gaia/resources/lib/debrid/easynews/core.py
@@ -163,7 +163,8 @@ class Core(base.Core):
 						'timestamp' : accountTimestamp,
 						'date' : accountExpiration.strftime('%Y-%m-%d'),
 						'remaining' : (accountExpiration - datetime.datetime.today()).days,
-					}
+					},
+					'usageHtml' : 'hi there'
 				}
 
 				if not minimal:
@@ -177,115 +178,12 @@ class Core(base.Core):
 					usageHtml = usageHtml.find_all('table', recursive = False)[0]
 					usageHtml = usageHtml.find_all('tr', recursive = False)
 
-					usageTotal = usageHtml[0].find_all('td', recursive = False)[1].getText()
-					index = usageTotal.find('(')
-					if index >= 0: usageTotal = int(usageTotal[index + 1 : usageTotal.find(' ', index)].replace(',', '').strip())
-					else: usageTotal = 0
+					account['usageTotal'] = usageHtml[0].find_all('td', recursive = False)[1].getText()
+					account['remaining'] = usageHtml[1].find_all('td', recursive = False)[2].getText()
+					usageLoyaltyTime = usageHtml[2].find_all('td', recursive = False)[2].getText()
 
-					usageConsumed = usageHtml[1].find_all('td', recursive = False)[2].getText()
-					index = usageConsumed.find('(')
-					if index >= 0: usageConsumed = int(usageConsumed[index + 1 : usageConsumed.find(' ', index)].replace(',', '').strip())
-					else: usageConsumed = 0
-
-					usageWeb = usageHtml[2].find_all('td', recursive = False)[2].getText()
-					index = usageWeb.find('(')
-					if index >= 0: usageWeb = int(usageWeb[index + 1 : usageWeb.find(' ', index)].replace(',', '').strip())
-					else: usageWeb = 0
-
-					usageNntp = usageHtml[3].find_all('td', recursive = False)[2].getText()
-					index = usageNntp.find('(')
-					if index >= 0: usageNntp = int(usageNntp[index + 1 : usageNntp.find(' ', index)].replace(',', '').strip())
-					else: usageNntp = 0
-
-					usageNntpUnlimited = usageHtml[4].find_all('td', recursive = False)[2].getText()
-					index = usageNntpUnlimited.find('(')
-					if index >= 0: usageNntpUnlimited = int(usageNntpUnlimited[index + 1 : usageNntpUnlimited.find(' ', index)].replace(',', '').strip())
-					else: usageNntpUnlimited = 0
-
-					usageRemaining = usageHtml[5].find_all('td', recursive = False)[2].getText()
-					index = usageRemaining.find('(')
-					if index >= 0: usageRemaining = int(usageRemaining[index + 1 : usageRemaining.find(' ', index)].replace(',', '').strip())
-					else: usageRemaining = 0
-
-					usageLoyalty = usageHtml[6].find_all('td', recursive = False)[2].getText()
-					index = usageLoyalty.find('(')
-					if index >= 0:
-						usageLoyaltyTime = usageLoyalty[:index].strip()
-						usageLoyaltyTimestamp = convert.ConverterTime(usageLoyaltyTime, format = convert.ConverterTime.FormatDate).timestamp()
-						usageLoyaltyTime = datetime.datetime.fromtimestamp(usageLoyaltyTimestamp)
-						usageLoyaltyPoints = float(usageLoyalty[index + 1 : usageLoyalty.find(')', index)].strip())
-					else:
-						usageLoyaltyTimestamp = 0
-						usageLoyaltyTime = None
-
-					usagePrecentageRemaining = usageRemaining / float(usageTotal)
-					usagePrecentageConsumed = usageConsumed / float(usageTotal)
-					usagePrecentageWeb = usageWeb / float(usageTotal)
-					usagePrecentageNntp = usageNntp / float(usageTotal)
-					usagePrecentageNntpUnlimited = usageNntpUnlimited / float(usageTotal)
-
-					account.update({
-						'loyalty' : {
-							'time' : {
-								'timestamp' : usageLoyaltyTimestamp,
-								'date' : usageLoyaltyTime.strftime('%Y-%m-%d')
-							},
-							'points' : usageLoyaltyPoints,
-						},
-						'usage' : {
-							'total' : {
-								'size' : {
-									'bytes' : usageTotal,
-									'description' : convert.ConverterSize(float(usageTotal)).stringOptimal(),
-								},
-							},
-							'remaining' : {
-								'value' : usagePrecentageRemaining,
-								'percentage' : round(usagePrecentageRemaining * 100.0, 1),
-								'size' : {
-									'bytes' : usageRemaining,
-									'description' : convert.ConverterSize(float(usageRemaining)).stringOptimal(),
-								},
-								'description' : '%.0f%%' % round(usagePrecentageRemaining * 100.0, 0), # Must round, otherwise 2.5% changes to 2% instead of 3%.
-							},
-							'consumed' : {
-								'value' : usagePrecentageConsumed,
-								'percentage' : round(usagePrecentageConsumed * 100.0, 1),
-								'size' : {
-									'bytes' : usageConsumed,
-									'description' : convert.ConverterSize(usageConsumed).stringOptimal(),
-								},
-								'description' : '%.0f%%' % round(usagePrecentageConsumed * 100.0, 0), # Must round, otherwise 2.5% changes to 2% instead of 3%.
-								'web' : {
-									'value' : usagePrecentageWeb,
-									'percentage' : round(usagePrecentageWeb * 100.0, 1),
-									'size' : {
-										'bytes' : usageWeb,
-										'description' : convert.ConverterSize(usageWeb).stringOptimal(),
-									},
-									'description' : '%.0f%%' % round(usagePrecentageWeb * 100.0, 0), # Must round, otherwise 2.5% changes to 2% instead of 3%.
-								},
-								'nntp' : {
-									'value' : usagePrecentageNntp,
-									'percentage' : round(usagePrecentageNntp * 100.0, 1),
-									'size' : {
-										'bytes' : usageNntp,
-										'description' : convert.ConverterSize(usageNntp).stringOptimal(),
-									},
-									'description' : '%.0f%%' % round(usagePrecentageNntp * 100.0, 0), # Must round, otherwise 2.5% changes to 2% instead of 3%.
-								},
-								'nntpunlimited' : {
-									'value' : usagePrecentageNntpUnlimited,
-									'percentage' : round(usagePrecentageNntpUnlimited * 100.0, 1),
-									'size' : {
-										'bytes' : usageNntpUnlimited,
-										'description' : convert.ConverterSize(usageNntpUnlimited).stringOptimal(),
-									},
-									'description' : '%.0f%%' % round(usagePrecentageNntpUnlimited * 100.0, 0), # Must round, otherwise 2.5% changes to 2% instead of 3%.
-								},
-							}
-						}
-					})
+					usageLoyaltyTime = usageLoyaltyTime[0 : usageLoyaltyTime.find(' ')].strip()
+					account['loyaltyDate'] = usageLoyaltyTime
 		except:
-			pass
+			tools.Logger.error()
 		return account

--- a/plugin.video.gaia/resources/lib/debrid/easynews/core.py
+++ b/plugin.video.gaia/resources/lib/debrid/easynews/core.py
@@ -163,8 +163,7 @@ class Core(base.Core):
 						'timestamp' : accountTimestamp,
 						'date' : accountExpiration.strftime('%Y-%m-%d'),
 						'remaining' : (accountExpiration - datetime.datetime.today()).days,
-					},
-					'usageHtml' : 'hi there'
+					}
 				}
 
 				if not minimal:
@@ -185,5 +184,5 @@ class Core(base.Core):
 					usageLoyaltyTime = usageLoyaltyTime[0 : usageLoyaltyTime.find(' ')].strip()
 					account['loyaltyDate'] = usageLoyaltyTime
 		except:
-			tools.Logger.error()
+			pass
 		return account

--- a/plugin.video.gaia/resources/lib/debrid/easynews/interface.py
+++ b/plugin.video.gaia/resources/lib/debrid/easynews/interface.py
@@ -53,17 +53,9 @@ class Interface(base.Interface):
 				date = account['expiration']['date']
 				days = str(account['expiration']['remaining'])
 
-				loyaltyDate = account['loyalty']['time']['date']
-				loyaltyPoints = '%.3f' % account['loyalty']['points']
-
-				total = convert.ConverterSize(account['usage']['total']['size']['bytes']).stringOptimal()
-				remaining = convert.ConverterSize(account['usage']['remaining']['size']['bytes']).stringOptimal() + (' (%.1f%%)' % account['usage']['remaining']['percentage'])
-				consumed = convert.ConverterSize(account['usage']['consumed']['size']['bytes']).stringOptimal() + (' (%.1f%%)' % account['usage']['consumed']['percentage'])
-				consumedWeb = convert.ConverterSize(account['usage']['consumed']['web']['size']['bytes']).stringOptimal() + (' (%.1f%%)' % account['usage']['consumed']['web']['percentage'])
-				consumedNntp = convert.ConverterSize(account['usage']['consumed']['nntp']['size']['bytes']).stringOptimal() + (' (%.1f%%)' % account['usage']['consumed']['nntp']['percentage'])
-				consumedNntpUnlimited = convert.ConverterSize(account['usage']['consumed']['nntpunlimited']['size']['bytes']).stringOptimal() + (' (%.1f%%)' % account['usage']['consumed']['nntpunlimited']['percentage'])
-
-				items = []
+				loyaltyDate = account['loyaltyDate']
+				total = account['usageTotal']
+				remaining = account['remaining']
 
 				items = []
 
@@ -91,8 +83,7 @@ class Interface(base.Interface):
 				items.append({
 					'title' : 33750,
 					'items' : [
-						{ 'title' : 33346, 'value' : loyaltyDate },
-						{ 'title' : 33349, 'value' : loyaltyPoints }
+						{ 'title' : 33346, 'value' : loyaltyDate }
 					]
 				})
 
@@ -101,11 +92,7 @@ class Interface(base.Interface):
 					'title' : 33228,
 					'items' : [
 						{ 'title' : 33497, 'value' : total },
-						{ 'title' : 33367, 'value' : remaining },
-						{ 'title' : 33754, 'value' : consumed },
-						{ 'title' : 33751, 'value' : consumedWeb },
-						{ 'title' : 33752, 'value' : consumedNntp },
-						{ 'title' : 33753, 'value' : consumedNntpUnlimited },
+						{ 'title' : 33367, 'value' : remaining }
 					]
 				})
 

--- a/plugin.video.gaia/resources/lib/providers/general/premium/member/easynews.py
+++ b/plugin.video.gaia/resources/lib/providers/general/premium/member/easynews.py
@@ -35,7 +35,7 @@ class source(provider.ProviderBase):
 		self.language = ['un']
 
 		self.domains = ['easynews.com']
-		self.base_link = 'http://members.easynews.com'
+		self.base_link = 'https://secure.members.easynews.com'
 
 		# safeO=1: removes adult content
 		# u=1: removes duplicates


### PR DESCRIPTION
on nov 16 2020 easynews switches to https only access:
To ensure your continued security, on November 16, 2020, Easynews will be upgrading services to support HTTPS only. All modern browsers will handle this transition automatically. If you have any questions, please contact us via our help page.
also, they changed much of the information on the usageview.jsp to remove the breakdown of usages.  
updated the baseurl of easynews to the secured endpoint and removed the unsupported breakdowns from the usages view.